### PR TITLE
Support for 16-bit platforms

### DIFF
--- a/src/vec32.rs
+++ b/src/vec32.rs
@@ -9,11 +9,15 @@
 
 #![allow(clippy::identity_conversion)]
 
-use std::{cmp, fmt, iter, mem, ops, ptr, slice, u32, vec};
-use std::ptr::NonNull;
 use std::convert::TryFrom;
+use std::ptr::NonNull;
+use std::{cmp, fmt, iter, mem, ops, ptr, slice, vec};
 
-#[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32", target_pointer_width = "64")))]
+#[cfg(not(any(
+    target_pointer_width = "16",
+    target_pointer_width = "32",
+    target_pointer_width = "64"
+)))]
 compile_error!("target_pointer_width must be 16, 32, or 64");
 
 #[cfg(target_pointer_width = "16")]
@@ -31,7 +35,7 @@ type usize32 = u32;
 /// On 64-bit platforms, the `Vec32<T>` struct takes up less space than the standard `Vec<T>`
 /// struct (16 bytes instead of 24 bytes), but its maximum capacity is `u32::MAX` instead of
 /// `usize::MAX`.
-/// 
+///
 /// Only 16-bit, 32-bit, and 64-bit platforms are currently supported.
 ///
 /// ## Warning
@@ -66,13 +70,11 @@ type usize32 = u32;
 /// ```
 /// #[macro_use] extern crate mediumvec;
 ///
-/// fn main() {
-///     let mut vec = vec32![1, 2, 3];
-///     assert_eq!(vec, [1, 2, 3]);
+/// let mut vec = vec32![1, 2, 3];
+/// assert_eq!(vec, [1, 2, 3]);
 ///
-///     let vec = vec32![0; 5];
-///     assert_eq!(vec, vec32![0, 0, 0, 0, 0]);
-/// }
+/// let vec = vec32![0; 5];
+/// assert_eq!(vec, vec32![0, 0, 0, 0, 0]);
 /// ```
 pub struct Vec32<T> {
     ptr: ptr::NonNull<T>,
@@ -84,22 +86,35 @@ impl<T> Vec32<T> {
     /// Constructs a new, empty vector.
     ///
     /// The vector will not allocate until elements are pushed onto it.
-    pub fn new() -> Vec32<T> {
-        Vec32 {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
             ptr: NonNull::dangling(),
-            cap: if mem::size_of::<T>() == 0 { usize32::max_value() } else { 0 },
+            cap: if mem::size_of::<T>() == 0 {
+                usize32::max_value()
+            } else {
+                0
+            },
             len: 0,
         }
     }
 
     /// Constructs a new, empty (length 0) vector with the specified capacity.
-    pub fn with_capacity(cap: u32) -> Vec32<T> {
+    #[must_use]
+    pub fn with_capacity(cap: u32) -> Self {
         let size = usize32::try_from(cap).expect("capacity overflow");
         let mut v = Vec::with_capacity(size as usize);
-        let ptr = NonNull::new(v.as_mut_ptr()).unwrap();
+        let ptr = unsafe {
+            // This is safe as long as `Vec<T>` upholds its invariants.
+            NonNull::new_unchecked(v.as_mut_ptr())
+        };
         mem::forget(v);
 
-        Vec32 { ptr, cap: size, len: 0 }
+        Self {
+            ptr,
+            cap: size,
+            len: 0,
+        }
     }
 
     /// Append an element to the vector.
@@ -135,17 +150,16 @@ impl<T> Vec32<T> {
     /// ## Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate mediumvec;
-    /// # fn main() {
+    /// #[macro_use] extern crate mediumvec;
+    ///
     /// let mut v = vec32![1, 2, 3];
     /// assert_eq!(v.remove(1), 2);
     /// assert_eq!(v, [1, 3]);
-    /// # }
     /// ```
     pub fn remove(&mut self, index: u32) -> T {
         let len = self.len;
         let ind = usize32::try_from(index).expect("index out of bounds");
-        assert!(ind < len);
+        assert!(ind < len, "index out of bounds");
         unsafe {
             let ptr = self.as_mut_ptr().offset(ind as isize);
             let ret = ptr::read(ptr);
@@ -162,19 +176,17 @@ impl<T> Vec32<T> {
     /// ## Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate mediumvec;
-    /// # fn main() {
+    /// #[macro_use] extern crate mediumvec;
     /// let mut vec = vec![1, 2, 3];
     /// vec.insert(1, 4);
     /// assert_eq!(vec, [1, 4, 2, 3]);
     /// vec.insert(4, 5);
     /// assert_eq!(vec, [1, 4, 2, 3, 5]);
-    /// # }
     /// ```
     pub fn insert(&mut self, index: u32, element: T) {
         let len = self.len;
         let ind = usize32::try_from(index).expect("index out of bounds");
-        assert!(ind <= len);
+        assert!(ind <= len, "index out of bounds");
         if len == self.cap {
             self.reserve(1);
         }
@@ -198,12 +210,12 @@ impl<T> Vec32<T> {
         let extra = usize32::try_from(additional).expect("capacity overflow");
         let min_cap = self.len.checked_add(extra).expect("capacity overflow");
         if min_cap <= self.cap {
-            return
+            return;
         }
         let double_cap = self.cap.saturating_mul(2);
         let new_cap = cmp::max(min_cap, double_cap);
-        let additional = new_cap - self.len;
-        self.reserve_exact(u32::from(additional));
+        let extra_exact = new_cap - self.len;
+        self.reserve_exact(u32::from(extra_exact));
     }
 
     /// Reserves the minimum capacity for `additional` more elements to be inserted.
@@ -221,7 +233,8 @@ impl<T> Vec32<T> {
     /// Panics if the vector's length is greater than `u32::MAX` or `usize::MAX`, whichever is smaller.
     ///
     /// Re-allocates only if the vector's capacity is greater than `u32::MAX`.
-    pub fn from_vec(mut vec: Vec<T>) -> Vec32<T> {
+    #[must_use]
+    pub fn from_vec(mut vec: Vec<T>) -> Self {
         let len = usize32::try_from(vec.len()).expect("capacity overflow");
 
         if vec.capacity() > usize32::max_value() as usize {
@@ -234,13 +247,17 @@ impl<T> Vec32<T> {
             usize32::try_from(vec.capacity()).expect("capacity overflow")
         };
 
-        let ptr = NonNull::new(vec.as_mut_ptr()).unwrap();
+        let ptr = unsafe {
+            // This is safe as long as `Vec<T>` upholds its invariants.
+            NonNull::new_unchecked(vec.as_mut_ptr())
+        };
         mem::forget(vec);
 
-        Vec32 { ptr, cap, len }
+        Self { ptr, cap, len }
     }
 
     /// Convert a `Vec32<T>` into a `Vec<T>` without re-allocating.
+    #[must_use]
     pub fn into_vec(self) -> Vec<T> {
         unsafe {
             let v = Vec::from_raw_parts(self.ptr.as_ptr(), self.len as usize, self.cap as usize);
@@ -256,20 +273,23 @@ impl<T> Vec32<T> {
     /// Panics if the vector's length increases to greater than `u32::MAX` or `usize::MAX`, whichever is smaller.
     ///
     /// ```
-    /// # #[macro_use] extern crate mediumvec;
-    /// # fn main() {
+    /// #[macro_use] extern crate mediumvec;
+    ///
     /// let mut v = vec32![0, 0, 0, 1, 1, 2, 3, 3, 3];
     /// v.as_vec(|vec| vec.dedup());
     /// assert_eq!(v, [0, 1, 2, 3]);
-    /// # }
     /// ```
-    pub fn as_vec<F>(&mut self, f: F) where F: FnOnce(&mut Vec<T>) {
-        let mut vec = mem::replace(self, Vec32::new()).into_vec();
+    pub fn as_vec<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut Vec<T>),
+    {
+        let mut vec = mem::replace(self, Self::new()).into_vec();
         f(&mut vec);
-        *self = Vec32::from_vec(vec);
+        *self = Self::from_vec(vec);
     }
 
     /// Returns the maximum number of elements the vector can hold without reallocating.
+    #[must_use]
     pub fn capacity(&self) -> u32 {
         u32::from(self.cap)
     }
@@ -306,14 +326,12 @@ impl<T> Vec32<T> {
 /// ```
 /// #[macro_use] extern crate mediumvec;
 ///
-/// # fn main() {
 /// let mut vec = vec32![1, 2, 3];
 /// vec.push(4);
 /// assert_eq!(vec, [1, 2, 3, 4]);
 ///
 /// let vec = vec32![0; 5];
 /// assert_eq!(vec, [0, 0, 0, 0, 0]);
-/// # }
 /// ```
 #[macro_export]
 macro_rules! vec32 {
@@ -328,6 +346,13 @@ macro_rules! vec32 {
 
 // Trait implementations:
 
+impl<T> Default for Vec32<T> {
+    #[must_use]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> Drop for Vec32<T> {
     fn drop(&mut self) {
         unsafe {
@@ -341,26 +366,24 @@ unsafe impl<T: Sync> Sync for Vec32<T> {}
 unsafe impl<T: Send> Send for Vec32<T> {}
 
 impl<T: Clone> Clone for Vec32<T> {
+    #[must_use]
     fn clone(&self) -> Self {
-        Vec32::from_vec(self[..].to_vec())
+        Self::from_vec(self[..].to_vec())
     }
 }
 
 impl<T> ops::Deref for Vec32<T> {
     type Target = [T];
 
+    #[must_use]
     fn deref(&self) -> &[T] {
-        unsafe {
-            slice::from_raw_parts(self.ptr.as_ptr(), self.len as usize)
-        }
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len as usize) }
     }
 }
 
 impl<T> ops::DerefMut for Vec32<T> {
     fn deref_mut(&mut self) -> &mut [T] {
-        unsafe {
-            slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len as usize)
-        }
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len as usize) }
     }
 }
 
@@ -368,6 +391,7 @@ impl<T> IntoIterator for Vec32<T> {
     type Item = T;
     type IntoIter = vec::IntoIter<T>;
 
+    #[must_use]
     fn into_iter(self) -> vec::IntoIter<T> {
         self.into_vec().into_iter()
     }
@@ -377,6 +401,7 @@ impl<'a, T> IntoIterator for &'a Vec32<T> {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;
 
+    #[must_use]
     fn into_iter(self) -> slice::Iter<'a, T> {
         self.iter()
     }
@@ -395,7 +420,7 @@ impl<T> Extend<T> for Vec32<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         let iterator = iter.into_iter();
         let lower = usize32::try_from(iterator.size_hint().0).expect("capacity overflow");
-        assert!(lower != usize32::max_value());
+        assert!(lower != usize32::max_value(), "capacity overflow");
         self.reserve(u32::from(lower));
 
         for i in iterator {
@@ -405,12 +430,12 @@ impl<T> Extend<T> for Vec32<T> {
 }
 
 impl<T> iter::FromIterator<T> for Vec32<T> {
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Vec32<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let iterator = iter.into_iter();
         let lower = usize32::try_from(iterator.size_hint().0).expect("capacity overflow");
-        assert!(lower != usize32::max_value());
+        assert!(lower != usize32::max_value(), "capacity overflow");
 
-        let mut v = Vec32::with_capacity(u32::from(lower));
+        let mut v = Self::with_capacity(u32::from(lower));
         for i in iterator {
             v.push(i);
         }
@@ -425,16 +450,21 @@ impl<T: fmt::Debug> fmt::Debug for Vec32<T> {
 }
 
 impl<T: PartialOrd> PartialOrd for Vec32<T> {
-    fn partial_cmp(&self, other: &Vec32<T>) -> Option<cmp::Ordering> {
+    #[must_use]
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
 }
 
 impl<T: Eq> Eq for Vec32<T> {}
 
-impl<T, U> PartialEq<U> for Vec32<T> where U: for<'a> PartialEq<&'a [T]> {
-    fn eq(&self, other: &U) -> bool { *other == &self[..] }
-    fn ne(&self, other: &U) -> bool { *other != &self[..] }
+impl<T, U> PartialEq<U> for Vec32<T>
+where
+    U: for<'a> PartialEq<&'a [T]>,
+{
+    fn eq(&self, other: &U) -> bool {
+        *other == &self[..]
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Behavior should remain the same for 32-bit and 64-bit platforms.

On 16-bit platforms, a `Vec32<T>` will be essentially the same as a `Vec<T>`. Instead of `u32` it uses `u16` internally, but the public API is unchanged. This change required adding some `try_from` conversions any time `u32` is coerced to `usize`, but as far as I can tell these are optimized out on 32-bit and 64-bit platforms.

I wasn't able to test on a true 16-bit platform, but the existing tests all run fine when overriding `cap` and `len` to be `u16`'s.

Any platform besides 16-bit, 32-bit, and 64-bit will produce a compile time error.