### PR TITLE
add extend_from_slice, add inlines

### DIFF
--- a/src/vec32.rs
+++ b/src/vec32.rs
@@ -99,7 +99,7 @@ impl<T> Vec32<T> {
             self.reserve(1);
         }
         unsafe {
-            let end = self.as_mut_ptr().offset(self.len as isize);
+            let end = self.as_mut_ptr().add(self.len as usize);
             ptr::write(end, value);
             self.len += 1;
         }
@@ -181,8 +181,8 @@ impl<T> Vec32<T> {
         }
 
         unsafe {
-            let p = self.as_mut_ptr().offset(index as isize);
-            ptr::copy(p, p.offset(1), (len - index) as usize);
+            let p = self.as_mut_ptr().add(index as usize);
+            ptr::copy(p, p.add(1), (len - index) as usize);
             ptr::write(p, element);
             self.len += 1;
         }
@@ -195,7 +195,6 @@ impl<T> Vec32<T> {
     /// Panics if the new capacity overflows `u32`.
     ///
     /// Re-allocates only if `self.capacity() < self.len() + additional`.
-    #[inline]
     pub fn reserve(&mut self, additional: u32) {
         let min_cap = self.len.checked_add(additional).expect("capacity overflow");
         if min_cap <= self.cap {
@@ -212,7 +211,6 @@ impl<T> Vec32<T> {
     /// Panics if the new capacity overflows `u32`.
     ///
     /// Re-allocates only if `self.capacity() < self.len() + additional`.
-    #[inline]
     pub fn reserve_exact(&mut self, additional: u32) {
         self.as_vec(|v| v.reserve_exact(additional as usize));
     }


### PR DESCRIPTION
This PR adds `extend_from_slice` which is pretty common and adds some missing `inline`

It also includes a bugfix for a panic in `pop`
```
running 5 tests
thread 'vec32::tests::it_works' panicked at library/core/src/panicking.rs:156:5:
unsafe precondition(s) violated: slice::get_unchecked requires that the index is within the slice
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:110:18
   2: core::panicking::panic_nounwind_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:123:9
   3: core::panicking::panic_nounwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:156:5
   4: <usize as core::slice::index::SliceIndex<[T]>>::get_unchecked::precondition_check
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/intrinsics.rs:2799:21
   5: <usize as core::slice::index::SliceIndex<[T]>>::get_unchecked
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/slice/index.rs:233:9
   6: core::slice::<impl [T]>::get_unchecked
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/slice/mod.rs:686:20
   7: mediumvec::vec32::Vec32<T>::pop
             at ./src/vec32.rs:127:42
   8: mediumvec::vec32::tests::it_works
             at ./src/vec32.rs:548:20
   9: mediumvec::vec32::tests::it_works::{{closure}}
             at ./src/vec32.rs:546:18
  10: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
  11: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `--lib`
```