### PR TITLE
Fix UB in pop/push under Stacked Borrows

### DIFF
--- a/src/vec32.rs
+++ b/src/vec32.rs
@@ -98,7 +98,7 @@ impl<T> Vec32<T> {
             self.reserve(1);
         }
         unsafe {
-            let end = self.as_mut_ptr().offset(self.len as isize);
+            let end = self.ptr.as_ptr().add(self.len as _);
             ptr::write(end, value);
             self.len += 1;
         }
@@ -111,7 +111,7 @@ impl<T> Vec32<T> {
         } else {
             unsafe {
                 self.len -= 1;
-                Some(ptr::read(self.get_unchecked(self.len as usize)))
+                Some(ptr::read(self.ptr.as_ptr().add(self.len as _)))
             }
         }
     }


### PR DESCRIPTION
`cargo miri test` reports that `Vec32::pop` and `Vec32::push` have UB under the Stacked Borrows model.

The UB occurs when a pointer is used to read/write out-of-bounds of the slice it was created from. This slice is conjured by auto-deref of `self` in both implementations.

https://github.com/mbrubeck/mediumvec/blob/398db615123c5172f9e44aee42ca1dc19b7d6d2c/src/vec32.rs#L113-L114

https://github.com/mbrubeck/mediumvec/blob/398db615123c5172f9e44aee42ca1dc19b7d6d2c/src/vec32.rs#L101-L103

In other words, we are dealing with a variant of https://github.com/rust-lang/unsafe-code-guidelines/issues/134

This PR silences miri by explicitly going through pointers so that we don't accidentally retag and reduce the provenance.